### PR TITLE
Update with MongoDb API 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ one-off script) you don't need to call it in your program. Of course, check
 the changelock to see if you need to update them with new releases:
 
 ```js
-queue.ensureIndexes(function(err) {
+queue.createIndexes(function(err, indexName) {
     // The indexes needed have been added to MongoDB.
 })
 ```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {},
   "devDependencies": {
     "tape": "^2.14.0",
-    "mongodb": "^1.4.9",
+    "mongodb": "^2.0.39",
     "async": "^0.9.0"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -7,13 +7,13 @@ var mongoDbQueue = require('../')
 setup(function(db) {
 
     test('visibility: check message is back in queue after 3s', function(t) {
-        t.plan(1)
+        t.plan(2)
 
         var queue = mongoDbQueue(db, 'visibility', { visibility : 3 })
 
-        queue.ensureIndexes(function(err) {
+        queue.createIndexes(function(err, indexName) {
             t.ok(!err, 'There was no error when running .ensureIndexes()')
-
+            t.ok(indexName, 'receive indexName we created')
             t.end()
         })
     })


### PR DESCRIPTION
Hi, Andy

As node.js mongoDB driver API already update to version 2.0, I update the library

`aad6b70` : update the mongodb API functions, detail information is in the commitment,
`73422d6` : update readMe.md, and mongoDB version in package.json,
`c60f4e9` :  update the test/indexs.js

I am not sure which version number you want to specify, so I didn't change the version.

This library fit very well for my project, except that I need to clean the acknowledged message, so I am thinking to change the it a little bit, maybe offer an option when creating the queue? How do you think about it?

thanks again for the library !

Hanwen