### PR TITLE
Handle case where _id is nested using Mongoose

### DIFF
--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -75,7 +75,7 @@ Queue.prototype.add = function(payload, opts, callback) {
     }
     self.col.insertOne(msg, function(err, results) {
         if (err) return callback(err)
-        callback(null, '' + results.ops[0]._id)
+        callback(null, '' + (results.ops || results)[0]._id)
     })
 }
 


### PR DESCRIPTION
When using Mongoose, we're finding that the results array item that contains `_id` is actually nested under the `ops` parameter. This patch checks for `results.ops[0]` first, otherwise defaulting to results[0].
