### PR TITLE
Allow many messages to be added in bulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,15 @@ queue.add({ err: 'E_BORKED', msg: 'Broken' }, function(err, id) {
 })
 ```
 
+Or add multiple messages:
+
+```js
+queue.add(['msg1', 'msg2', 'msg3'], function(err, ids) {
+    // Messages with payloads 'msg1', 'msg2' & 'msg3' added.
+    // All 'id's are returned as an array, useful for logging.
+})
+```
+
 You can delay individual messages from being visible by passing the `delay` option:
 
 ```js
@@ -263,6 +272,7 @@ Retrieve a message from the queue:
 ```js
 queue.get(function(err, msg) {
     // You can now process the message
+    // IMPORTANT: The callback will not wait for an message if the queue is empty.  The message will be undefined if the queue is empty.
 })
 ```
 

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -69,12 +69,26 @@ Queue.prototype.add = function(payload, opts, callback) {
         opts = {}
     }
     var delay = opts.delay || self.delay
-    var msg = {
-        visible  : delay ? nowPlusSecs(delay) : now(),
-        payload  : payload,
+    var visible = delay ? nowPlusSecs(delay) : now()
+
+    var msgs = []
+    if (payload instanceof Array) {
+        payload.forEach(function(payload) {
+            msgs.push({
+                visible  : visible,
+                payload  : payload,
+            })
+        })
+    } else {
+        msgs.push({
+            visible  : visible,
+            payload  : payload,
+        })
     }
-    self.col.insertOne(msg, function(err, results) {
+
+    self.col.insertMany(msgs, function(err, results) {
         if (err) return callback(err)
+        if (payload instanceof Array) return callback(null, '' + results.insertedIds)
         callback(null, '' + results.ops[0]._id)
     })
 }

--- a/test/many.js
+++ b/test/many.js
@@ -1,0 +1,73 @@
+var async = require('async')
+var test = require('tape')
+
+var setup = require('./setup.js')
+var mongoDbQueue = require('../')
+
+var total = 250
+
+setup(function(db) {
+
+    test('many: add ' + total + ' messages, get ' + total + ' back', function(t) {
+        var queue = mongoDbQueue(db, 'many')
+        var msgs = []
+        var msgsToQueue = []
+
+        async.series(
+            [
+                function(next) {
+                    var i
+                    for(i=0; i<total; i++) {
+                        msgsToQueue.push('no=' + i)
+                    }
+                    queue.add(msgsToQueue, function(err) {
+                        if (err) return t.fail('Failed adding a message')
+                        t.pass('All ' + total + ' messages sent to MongoDB')
+                        next()
+                    })
+                },
+                function(next) {
+                    function getOne() {
+                        queue.get(function(err, msg) {
+                            if (err || !msg) return t.fail('Failed getting a message')
+                            msgs.push(msg)
+                            if (msgs.length === total) {
+                                t.pass('Received all ' + total + ' messages')
+                                next()
+                            }
+                            else {
+                                getOne()
+                            }
+                        })
+                    }
+                    getOne()
+                },
+                function(next) {
+                    var acked = 0
+                    msgs.forEach(function(msg) {
+                        queue.ack(msg.ack, function(err) {
+                            if (err) return t.fail('Failed acking a message')
+                            acked++
+                            if (acked === total) {
+                                t.pass('Acked all ' + total + ' messages')
+                                next()
+                            }
+                        })
+                    })
+                },
+            ],
+            function(err) {
+                if (err) t.fail(err)
+                t.pass('Finished test ok')
+                t.end()
+            }
+        )
+    })
+
+    test('db.close()', function(t) {
+        t.pass('db.close()')
+        db.close()
+        t.end()
+    })
+
+})


### PR DESCRIPTION
Hi @chilts,
This change allows an array of messages to be added with 1 call to
`Queue.add()`. The callback signature changes in this scenario and
gives an array of id's for the added messages.
The underlying logic makes use of `collection.insertMany`, sending
all messages to mongodb in 1 call.

What are your thoughts on adding this change?