### PR TITLE
Fix intermittent test failures that are based on timing queries.

### DIFF
--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -103,7 +103,7 @@ Queue.prototype.get = function(opts, callback) {
     var visibility = opts.visibility || self.visibility
     var query = {
         deleted : null,
-        visible : { $lt : now() },
+        visible : { $lte : now() },
     }
     var sort = {
         _id : 1
@@ -225,7 +225,7 @@ Queue.prototype.size = function(callback) {
 
     var query = {
         deleted : null,
-        visible : { $lt : now() },
+        visible : { $lte : now() },
     }
 
     self.col.count(query, function(err, count) {


### PR DESCRIPTION
Hi @chilts,
I had a look into the intermittent test failures and believe this should help.
This problem only happens if the visible timestamp is exactly the same as the timestamp when trying to get a job.

This fix changes the `queue.get()` functionality slightly by using
'less than or equal to' ($lte) when comparing to the current time.
This ensures that any newly added jobs to a queue can be retrieved
straight away i.e. a test can add a job, then get it without having to
wait until a small amount of time has passed and the job is 'visible'.

