### PR TITLE
Fail gracefully when adding an empty array

### DIFF
--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -73,6 +73,10 @@ Queue.prototype.add = function(payload, opts, callback) {
 
     var msgs = []
     if (payload instanceof Array) {
+        if (payload.length === 0) {
+            var errMsg = 'Queue.add(): Array payload length must be greater than 0'
+            return callback(new Error(errMsg))
+        }
         payload.forEach(function(payload) {
             msgs.push({
                 visible  : visible,

--- a/test/many.js
+++ b/test/many.js
@@ -64,6 +64,16 @@ setup(function(db) {
         )
     })
 
+    test('many: add no messages, receive err in callback', function(t) {
+        var queue = mongoDbQueue(db, 'many')
+        var messages = []
+        queue.add([], function(err) {
+            if (!err) t.fail('Error was not received')
+            t.pass('Finished test ok')
+            t.end()
+        });
+    })
+
     test('db.close()', function(t) {
         t.pass('db.close()')
         db.close()


### PR DESCRIPTION
Currently when adding an empty array using `queue.add` an error will
be thrown by MongoDB clients (at least in version 2.x.x), this performs 
a check on the payload of `add`. 

If it's an array with a length of 0 an error with a more descriptive message
will be returned instead of `MongoError: Invalid Operation, No operations in bulk`
being thrown.