### PR TITLE
Add 'Add if missing' functionality. Make id seperate from mongo document id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ queue.ack(msg.ack, function(err, id) {
 })
 ```
 
+Remove a non visible message from the queue:
+
+```js
+queue.cancel(id, function(err) {
+    // err if in flight, already acked, or invalid id
+})
+```
+
 By default, all old messages - even processed ones - are left in MongoDB. This is so that
 you can go and analyse them if you want. However, you can call the following function
 to remove processed messages:

--- a/README.md
+++ b/README.md
@@ -272,6 +272,24 @@ queue.add('Later', { delay: 120 }, function(err, id) {
     // This message won't be available for getting for 2 mins.
 })
 ```
+### .addIfMissing() ###
+
+The same as add but allows you to specify the id. If a message with that id has already been added to the queue,
+this request is ignored.
+
+```js
+queue.addIfMissing(1,'Hello, World!', function(err, id) {
+    // Message with payload 'Hello, World!' added.
+    // 'id' is returned if a new message was inserted, null if it already existed
+})
+```
+The id can be of any type. It will be returned to you in the same form you provide to use in methods requiring the id.
+```js
+queue.addIfMissing('abc123','Hello, World!', function(err, id) {
+    // Message with payload 'Hello, World!' added.
+    // 'id' is returned if a new message was inserted, null if it already existed
+})
+```
 
 ### .get() ###
 

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -77,9 +77,9 @@ Queue.prototype.addIfMissing = function(id, payload, opts, callback) {
     payload  : payload,
   }
 
-  self.col.updateOne({_id: id}, { $setOnInsert: msg }, { upsert: true }, function(err) {
+  self.col.updateOne({_id: id}, { $setOnInsert: msg }, { upsert: true }, function(err, result) {
     if (err) return callback(err)
-    callback(null, id)
+    callback(null, result.nUpserted === 1 ? id : null)
   })
 }
 

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -79,7 +79,7 @@ Queue.prototype.addIfMissing = function(id, payload, opts, callback) {
 
   self.col.updateOne({ id : id }, { $setOnInsert: msg }, { upsert: true }, function(err, result) {
     if (err) return callback(err)
-    callback(null, result.nUpserted === 1 ? id : null)
+    callback(null, result.upsertedCount === 1 ? id : null)
   })
 }
 

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -77,7 +77,7 @@ Queue.prototype.addIfMissing = function(id, payload, opts, callback) {
     payload  : payload,
   }
 
-  self.col.updateOne({_id: id}, { $setOnInsert: msg}, { upsert: true }, function(err) {
+  self.col.updateOne({_id: id}, { $setOnInsert: msg }, { upsert: true }, function(err) {
     if (err) return callback(err)
     callback(null, id)
   })

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -11,7 +11,6 @@
  **/
 
 var crypto = require('crypto')
-var ObjectID = require('mongodb').ObjectID
 
 // some helper functions
 function id() {
@@ -93,8 +92,8 @@ Queue.prototype.add = function(payload, opts, callback) {
 
     self.col.insertMany(msgs, function(err, results) {
         if (err) return callback(err)
-        if (payload instanceof Array) return callback(null, '' + results.insertedIds)
-        callback(null, '' + results.ops[0]._id)
+        if (payload instanceof Array) return callback(null, results.insertedIds)
+        callback(null, results.ops[0]._id)
     })
 }
 
@@ -128,8 +127,7 @@ Queue.prototype.get = function(opts, callback) {
 
         // convert to an external representation
         msg = {
-            // convert '_id' to an 'id' string
-            id      : '' + msg._id,
+            id      : msg._id,
             ack     : msg.ack,
             payload : msg.payload,
             tries   : msg.tries,
@@ -175,12 +173,12 @@ Queue.prototype.ping = function(ack, opts, callback) {
             visible : nowPlusSecs(visibility)
         }
     }
-    self.col.findOneAndUpdate(query, update, { returnOriginal : false }, function(err, msg, blah) {
+    self.col.findOneAndUpdate(query, update, { returnOriginal : false }, function(err, msg) {
         if (err) return callback(err)
         if ( !msg.value ) {
             return callback(new Error("Queue.ping(): Unidentified ack  : " + ack))
         }
-        callback(null, '' + msg.value._id)
+        callback(null, msg.value._id)
     })
 }
 
@@ -197,12 +195,12 @@ Queue.prototype.ack = function(ack, callback) {
             deleted : now(),
         }
     }
-    self.col.findOneAndUpdate(query, update, { returnOriginal : false }, function(err, msg, blah) {
+    self.col.findOneAndUpdate(query, update, { returnOriginal : false }, function(err, msg) {
         if (err) return callback(err)
         if ( !msg.value ) {
             return callback(new Error("Queue.ack(): Unidentified ack : " + ack))
         }
-        callback(null, '' + msg.value._id)
+        callback(null, msg.value._id)
     })
 }
 
@@ -271,7 +269,7 @@ Queue.prototype.cancel = function(id, callback) {
     var self = this
 
     var query = {
-        _id     : new ObjectID(id),
+        _id     : id,
         deleted : null,
         visible : { $lte : now() },
     }
@@ -280,7 +278,7 @@ Queue.prototype.cancel = function(id, callback) {
             deleted : now(),
         }
     }
-    self.col.findOneAndUpdate(query, update, { returnOriginal : false }, function(err, msg, blah) {
+    self.col.findOneAndUpdate(query, update, { returnOriginal : false }, function(err, msg) {
         if (err) return callback(err)
         if ( !msg.value ) {
           return callback(new Error("Queue.cancel(): Unidentified id : " + id))

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -136,7 +136,7 @@ Queue.prototype.get = function(opts, callback) {
         visible : { $lte : now() },
     }
     var sort = {
-        id : 1
+        _id : 1
     }
     var update = {
         $inc : { tries : 1 },

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -62,6 +62,27 @@ Queue.prototype.createIndexes = function(callback) {
     })
 }
 
+Queue.prototype.addIfMissing = function(id, payload, opts, callback) {
+  var self = this
+  if ( !callback ) {
+    callback = opts
+    opts = {}
+  }
+  var delay = opts.delay || self.delay
+  var visible = delay ? nowPlusSecs(delay) : now()
+
+  var msg = {
+    _id : id,
+    visible  : visible,
+    payload  : payload,
+  }
+
+  self.col.updateOne({_id: id}, { $setOnInsert: msg}, { upsert: true }, function(err) {
+    if (err) return callback(err)
+    callback(null, id)
+  })
+}
+
 Queue.prototype.add = function(payload, opts, callback) {
     var self = this
     if ( !callback ) {

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -55,7 +55,7 @@ Queue.prototype.createIndexes = function(callback) {
 
     self.col.createIndex({ deleted : 1, visible : 1 }, function(err, indexname) {
         if (err) return callback(err)
-        self.col.createIndex({ ack : 1 }, { unique : true, sparse : true }, function(err) {
+        self.col.createIndex({ ack : 1, id: 1 }, { unique : true, sparse : true }, function(err) {
             if (err) return callback(err)
             callback(null, indexname)
         })

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -42,7 +42,6 @@ function Queue(mongoDbClient, name, opts) {
 
     this.name = name
     this.col = mongoDbClient.collection(name)
-    this.objectId = mongoDbClient.ObjectID
     this.visibility = opts.visibility || 30
     this.delay = opts.delay || 0
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "test": "set -e; for FILE in test/*.js; do node $FILE; done"
   },
   "dependencies": {
-    "mongodb": "^2.2.24"
+    "mongodb": "^2.0.48"
   },
   "devDependencies": {
     "tape": "^4.2.2",
-    "mongodb": "^2.0.48",
     "async": "^1.5.0"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {},
   "devDependencies": {
     "tape": "^4.2.2",
+    "mongodb": "^2.0.48",
     "async": "^1.5.0"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "mongodb-queue",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {
     "test": "set -e; for FILE in test/*.js; do node $FILE; done"
   },
-  "dependencies": {
-    "mongodb": "^2.0.48"
-  },
+  "dependencies": {},
   "devDependencies": {
     "tape": "^4.2.2",
     "async": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "set -e; for FILE in test/*.js; do node $FILE; done"
   },
-  "dependencies": {},
+  "dependencies": {
+    "mongodb": "^2.2.24"
+  },
   "devDependencies": {
     "tape": "^4.2.2",
     "mongodb": "^2.0.48",

--- a/test/addIfMissing.js
+++ b/test/addIfMissing.js
@@ -20,8 +20,9 @@ setup(function(db) {
             })
           },
           function(next) {
-            queue.addIfMissing(1, {abc:123}, {}, function(err) {
+            queue.addIfMissing(1, {abc:123}, {}, function(err, id) {
               t.ok(!err, 'There is no error.')
+              t.equal(id, 1, 'The id returned mathces what was specified')
               next()
             })
           },
@@ -40,8 +41,9 @@ setup(function(db) {
             })
           },
           function(next) {
-            queue.addIfMissing(1, {abc:123}, {}, function(err) {
+            queue.addIfMissing(1, {abc:123}, {}, function(err, id) {
               t.ok(!err, 'There is no error.')
+              t.ok(!id, 'No id is returned.');
               next()
             })
           },
@@ -60,8 +62,9 @@ setup(function(db) {
             })
           },
           function(next) {
-            queue.addIfMissing(1, {abc:456}, {}, function(err) {
+            queue.addIfMissing(1, {abc:456}, {}, function(err, id) {
               t.ok(!err, 'There is no error.')
+              t.ok(!id, 'No id is returned.');
               next()
             })
           },
@@ -108,8 +111,9 @@ setup(function(db) {
             })
           },
           function(next) {
-            queue.addIfMissing(1, {abc:123}, {}, function(err) {
+            queue.addIfMissing(1, {abc:123}, {}, function(err, id) {
               t.ok(!err, 'There is no error.')
+              t.ok(!id, 'No id is returned.');
               next()
             })
           },
@@ -134,6 +138,13 @@ setup(function(db) {
               next()
             })
           },
+          function(next) {
+            queue.addIfMissing('abc456', {}, {}, function(err, id){
+              t.ok(!err, 'There is no error.')
+              t.equal(id, 'abc456', 'The id matches what was specified')
+              next()
+            })
+          }
         ],
         function(err) {
           if (err) t.fail(err)

--- a/test/addIfMissing.js
+++ b/test/addIfMissing.js
@@ -1,0 +1,153 @@
+var async = require('async')
+var test = require('tape')
+
+var setup = require('./setup.js')
+var mongoDbQueue = require('../')
+
+setup(function(db) {
+
+  test('addIfMissing: check duplicated messages are not added', function(t) {
+    var queue = mongoDbQueue(db, 'addIfMissing', { visibility : 3 })
+    var msg
+
+    async.waterfall(
+        [
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing in the queue at all')
+              next()
+            })
+          },
+          function(next) {
+            queue.addIfMissing(1, {abc:123}, {}, function(err) {
+              t.ok(!err, 'There is no error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.addIfMissing(1, {abc:123}, {}, function(err) {
+              t.ok(!err, 'There is no error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.addIfMissing(1, {abc:456}, {}, function(err) {
+              t.ok(!err, 'There is no error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.get({}, function(err, msg){
+              t.ok(!err, 'There is no error.')
+              t.equal(msg.payload.abc, 123, 'The payload is the first one entered')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing in the queue at all')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.get({}, function(err, msg){
+              t.ok(!err, 'There is no error.')
+              t.ok(!msg, 'The message is not retrieved again.')
+              next()
+            })
+          },
+          function(next) {
+            queue.addIfMissing(1, {abc:123}, {}, function(err) {
+              t.ok(!err, 'There is no error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing in the queue at all')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'There is currently one item in the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.get({}, function(err, msg){
+              t.ok(!err, 'There is no error.')
+              t.ok(!msg, 'The message is not retrieved again.')
+              next()
+            })
+          },
+        ],
+        function(err) {
+          if (err) t.fail(err)
+          t.pass('Finished test ok')
+          t.end()
+        }
+    )
+  })
+
+  test('db.close()', function(t) {
+    t.pass('db.close()')
+    db.close()
+    t.end()
+  })
+
+})
+

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -1,0 +1,144 @@
+var async = require('async')
+var test = require('tape')
+
+var setup = require('./setup.js')
+var mongoDbQueue = require('../')
+
+setup(function(db) {
+
+  test('clean: check deleted messages are deleted', function(t) {
+    var queue = mongoDbQueue(db, 'clean', { visibility : 3 })
+    var msg
+
+    async.waterfall(
+        [
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing on the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing in the queue at all')
+              next()
+            })
+          },
+          function(next) {
+            queue.clean(function(err) {
+              t.ok(!err, 'There is no error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing on the queue')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'There is currently nothing in the queue at all')
+              next()
+            })
+          },
+          function(next) {
+            queue.add('Hello, World!', function(err, id) {
+              t.ok(!err, 'There is no error when adding a message.')
+              next(null, id)
+            })
+          },
+          function(id, next) {
+            queue.clean(function(err) {
+              t.ok(!err, 'There is no error.')
+              next(null, id)
+            })
+          },
+          function(id, next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'Queue size is correct')
+              next(null, id)
+            })
+          },
+          function(id, next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'Queue total is correct')
+              next(null, id)
+            })
+          },
+          function(id, next) {
+            queue.cancel(id, function(err) {
+              t.ok(!err, 'There is no error.')
+              next(null, id)
+            })
+          },
+          function(id, next) {
+            queue.get(function(err, msg) {
+              t.ok(!err, 'There is no error.')
+              t.ok(!msg, 'No msg received')
+              next(null, id)
+            })
+          },
+          function(id, next) {
+            queue.cancel(id, function(err) {
+              t.ok(err, 'There is an error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'Queue size is correct')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 1, 'Queue total is correct')
+              next()
+            })
+          },
+          function(next) {
+            queue.clean(function(err) {
+              t.ok(!err, 'There is no error.')
+              next()
+            })
+          },
+          function(next) {
+            queue.size(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'Queue size is correct')
+              next()
+            })
+          },
+          function(next) {
+            queue.total(function(err, size) {
+              t.ok(!err, 'There is no error.')
+              t.equal(size, 0, 'Queue total is correct')
+              next()
+            })
+          },
+        ],
+        function(err) {
+          if (err) t.fail(err)
+          t.pass('Finished test ok')
+          t.end()
+        }
+    )
+  })
+
+  test('db.close()', function(t) {
+    t.pass('db.close()')
+    db.close()
+    t.end()
+  })
+
+})
+

--- a/test/dead-queue.js
+++ b/test/dead-queue.js
@@ -79,7 +79,7 @@ setup(function(db) {
                     deadQueue.get(function(err, msg) {
                         t.ok(!err, 'No error when getting from the deadQueue')
                         t.ok(msg.id, 'Got a message id from the deadQueue')
-                        t.equal(msg.payload.id, origId, 'Got the same message id as the original message')
+                        t.equal(msg.payload.id.toString(), origId.toString(), 'Got the same message id as the original message')
                         t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message')
                         t.equal(msg.payload.tries, 6, 'Got the tries as 6')
                         next()
@@ -119,7 +119,7 @@ setup(function(db) {
                 },
                 function(next) {
                     queue.get(function(err, thisMsg) {
-                        t.equal(thisMsg.id, origId, 'We return the first message on first go')
+                        t.equal(thisMsg.id.toString(), origId.toString(), 'We return the first message on first go')
                         setTimeout(function() {
                             t.pass('First expiration')
                             next()
@@ -128,7 +128,7 @@ setup(function(db) {
                 },
                 function(next) {
                     queue.get(function(err, thisMsg) {
-                        t.equal(thisMsg.id, origId, 'We return the first message on second go')
+                        t.equal(thisMsg.id.toString(), origId.toString(), 'We return the first message on second go')
                         setTimeout(function() {
                             t.pass('Second expiration')
                             next()
@@ -137,7 +137,7 @@ setup(function(db) {
                 },
                 function(next) {
                     queue.get(function(err, thisMsg) {
-                        t.equal(thisMsg.id, origId, 'We return the first message on third go')
+                        t.equal(thisMsg.id.toString(), origId.toString(), 'We return the first message on third go')
                         setTimeout(function() {
                             t.pass('Third expiration')
                             next()
@@ -149,7 +149,7 @@ setup(function(db) {
                     // pior to it being returned.
                     queue.get(function(err, msg) {
                         t.ok(!err, 'No error when getting the 2nd message')
-                        t.equal(msg.id, origId2, 'Got the ID of the 2nd message')
+                        t.equal(msg.id.toString(), origId2.toString(), 'Got the ID of the 2nd message')
                         t.equal(msg.payload, 'Part II', 'Got the same payload as the 2nd message')
                         next()
                     })
@@ -158,7 +158,7 @@ setup(function(db) {
                     deadQueue.get(function(err, msg) {
                         t.ok(!err, 'No error when getting from the deadQueue')
                         t.ok(msg.id, 'Got a message id from the deadQueue')
-                        t.equal(msg.payload.id, origId, 'Got the same message id as the original message')
+                        t.equal(msg.payload.id.toString(), origId.toString(), 'Got the same message id as the original message')
                         t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message')
                         t.equal(msg.payload.tries, 4, 'Got the tries as 4')
                         next()

--- a/test/default.js
+++ b/test/default.js
@@ -30,7 +30,7 @@ setup(function(db) {
                         console.log(thisMsg)
                         msg = thisMsg
                         t.ok(msg.id, 'Got a msg.id')
-                        t.equal(typeof msg.id, 'object', 'msg.id is a string')
+                        t.equal(typeof msg.id, 'string', 'msg.id is a string')
                         t.ok(msg.ack, 'Got a msg.ack')
                         t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
                         t.ok(msg.tries, 'Got a msg.tries')
@@ -72,7 +72,7 @@ setup(function(db) {
                     queue.get(function(err, thisMsg) {
                         msg = thisMsg
                         t.ok(msg.id, 'Got a msg.id')
-                        t.equal(typeof msg.id, 'object', 'msg.id is a string')
+                        t.equal(typeof msg.id, 'string', 'msg.id is a string')
                         t.ok(msg.ack, 'Got a msg.ack')
                         t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
                         t.ok(msg.tries, 'Got a msg.tries')

--- a/test/default.js
+++ b/test/default.js
@@ -30,7 +30,7 @@ setup(function(db) {
                         console.log(thisMsg)
                         msg = thisMsg
                         t.ok(msg.id, 'Got a msg.id')
-                        t.equal(typeof msg.id, 'string', 'msg.id is a string')
+                        t.equal(typeof msg.id, 'object', 'msg.id is a string')
                         t.ok(msg.ack, 'Got a msg.ack')
                         t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
                         t.ok(msg.tries, 'Got a msg.tries')
@@ -72,7 +72,7 @@ setup(function(db) {
                     queue.get(function(err, thisMsg) {
                         msg = thisMsg
                         t.ok(msg.id, 'Got a msg.id')
-                        t.equal(typeof msg.id, 'string', 'msg.id is a string')
+                        t.equal(typeof msg.id, 'object', 'msg.id is a string')
                         t.ok(msg.ack, 'Got a msg.ack')
                         t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
                         t.ok(msg.tries, 'Got a msg.tries')


### PR DESCRIPTION
I needed the ability to add a message only if a message with the previous id does not exist. This allows some distributed use cases such as a ChronJob to be implemented on top of this library. In adding this functionality I realised that having a separate id field in the document would allow us to have cancel functionality while maintaining backwards compatibility with previous versions. 