### PR TITLE
Add kill command

### DIFF
--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -265,3 +265,19 @@ Queue.prototype.done = function(callback) {
         callback(null, count)
     })
 }
+
+Queue.prototype.kill = function(msg, callback) {
+    var self = this
+    if ( self.deadQueue ) {
+        // 1) add this message to the deadQueue
+        // 2) ack this message from the regular queue
+        self.deadQueue.add(msg, function(err) {
+            if (err) return callback(err)
+            self.ack(msg.ack, function(err) {
+                if (err) return callback(err)
+            })
+        })
+    }
+
+    return callback(null, msg)
+}


### PR DESCRIPTION
This adds a kill() function to remove a message from the active queue immediately and add it to the dead queue.

This is useful for messages that you know cannot be completed regardless of retries.