### PR TITLE
Allow setting delay as a Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ var queue = mongoDbQueue(db, 'queue', { delay : 10 })
 
 This is now the default for every message added to the queue.
 
+If you set `delay` to be a Date it will delay the message until that date.
+
+To delay all messages until January 1st 2077, try this:
+```
+var queue = mongoDbQueue(db, 'queue', { delay : new Date('2077-01-01') })
+```
+
 ### deadQueue - Dead Message Queue ###
 
 Default: none

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -69,7 +69,12 @@ Queue.prototype.add = function(payload, opts, callback) {
         opts = {}
     }
     var delay = opts.delay || self.delay
-    var visible = delay ? nowPlusSecs(delay) : now()
+    var visible = now()
+    if(typeof(delay.toISOString) === 'function') {
+        visible = delay.toISOString()        
+    } else if(typeof(delay) === 'number'){
+        visible = nowPlusSecs(delay)
+    }
 
     var msgs = []
     if (payload instanceof Array) {

--- a/test/delay.js
+++ b/test/delay.js
@@ -52,6 +52,52 @@ setup(function(db) {
         )
     })
 
+    test('delay: check an individual message delay of type Date overrides the queue delay ', function(t) {
+        var queue = mongoDbQueue(db, 'delay')
+
+        async.series(
+            [
+                function(next) {
+                  queue.add('I am delayed by 3 seconds', { delay : new Date(Date.now() + 3000) }, function(err, id) {
+                        t.ok(!err, 'There is no error when adding a message.')
+                        t.ok(id, 'There is an id returned when adding a message.')
+                        next()
+                    })
+                },
+                function(next) {
+                    // get something now and it shouldn't be there
+                    queue.get(function(err, msg) {
+                        t.ok(!err, 'No error when getting no messages')
+                        t.ok(!msg, 'No msg received')
+                        // now wait 4s
+                        setTimeout(next, 4 * 1000)
+                    })
+                },
+                function(next) {
+                    // get something now and it SHOULD be there
+                    queue.get(function(err, msg) {
+                        t.ok(!err, 'No error when getting a message')
+                        t.ok(msg.id, 'Got a message id now that the message delay has passed')
+                        queue.ack(msg.ack, next)
+                    })
+                },
+                function(next) {
+                    queue.get(function(err, msg) {
+                        // no more messages
+                        t.ok(!err, 'No error when getting no messages')
+                        t.ok(!msg, 'No more messages')
+                        next()
+                    })
+                },
+            ],
+            function(err) {
+                if (err) t.fail(err)
+                t.pass('Finished test ok')
+                t.end()
+            }
+        )
+    })
+
     test('delay: check an individual message delay overrides the queue delay', function(t) {
         var queue = mongoDbQueue(db, 'delay')
 


### PR DESCRIPTION
Adding ability to set a static Date for the delay instead of number of seconds.

This is useful if you want to schedule a bunch of messages to be available all at the same time.
(Such as sending push notifications to thousands of users at 9am for example.)